### PR TITLE
RDSEED fix for correct CPUID usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CC=gcc
-CFLAGS=-I ./include
+CFLAGS=-g -I ./include
 ARCH=
 DEPS=./include/intel_random.h ./src/*.S
 BIN_32=test_random_32

--- a/src/random_32.S
+++ b/src/random_32.S
@@ -31,9 +31,12 @@ rdrand_capability:
 
    mov   $1,   %eax
    cpuid
-
-   mov   $1,   %edi
-   shl   $30,  %edi   # 30th bit of ECX for RDRAND
+   
+   /*
+    mov   $1,   %edi
+    shl   $30,  %edi   # 30th bit of ECX for RDRAND
+   */
+   mov   $0x40000000, %edi # 0x40000000 is 30th bit set
    test  %ecx, %edi
    jz    no_rdrand    # RDRAND not supported
 
@@ -57,11 +60,15 @@ rdseed_capability:
 
    mov   %ebx, %esi   # Save EBX since CPUID clobbers EBX
 
-   mov   $1,   %eax
+   mov   $7,   %eax   # EAX=7 & ECX=0 to get Extended Features
+   mov   $0,   %ecx
    cpuid
 
+/*
    mov   $1,   %edi
    shl   $18,  %edi   # 18th bit of EBX for RDSEED
+*/
+   mov   $0x40000, %edi # 0x40000 is 18th bit set
    test  %ebx, %edi
    jz    no_rdseed    # RDSEED not supported
 

--- a/src/random_64.S
+++ b/src/random_64.S
@@ -33,8 +33,11 @@ rdrand_capability:
    movq  $1,   %rax
    cpuid
 
-   movl  $1,   %r8d
-   shl   $30,  %r8d   # 30th bit of ECX for RDRAND
+/*
+    movl  $1,   %r8d
+    shl   $30,  %r8d   # 30th bit of ECX for RDRAND
+*/
+   mov   $0x40000000, %r8d # 0x40000000 is 30th bit set
    test  %ecx, %r8d
    jz    no_rdrand    # RDRAND not supported
 
@@ -58,11 +61,15 @@ rdseed_capability:
 
    mov   %rbx, %rsi   # Save RBX since CPUID clobbers RBX
 
-   mov   $1,   %rax
+   mov   $7,   %rax   # EAX=7 & ECX=0 to get Extended Features
+   mov   $0,   %rcx
    cpuid
 
+/*
    mov   $1,   %r8d
    shl   $18,  %r8d   # 18th bit of EBX for RDSEED
+*/
+   mov   $0x40000, %r8d # 0x40000 is 18th bit set
    test  %ebx, %r8d
    jz    no_rdseed    # RDSEED not supported
 


### PR DESCRIPTION
- Fixing bug to correctly obtain RDSEED capability via the CPUID instruction
- Updated Makefile to add debug flags

Closes #1 