### PR TITLE
Renaming the ASM routine/function names to be OS X friendly.

### DIFF
--- a/include/intel_random.h
+++ b/include/intel_random.h
@@ -26,27 +26,52 @@
 #include <stdbool.h>
 
 #ifdef __x86_64__
-extern uint64_t random_64();
-#endif
-
-extern uint32_t random_32();
-extern uint16_t random_16();
-
-extern uint8_t rdrand_capability();
-extern uint8_t rdseed_capability();
+extern uint64_t _random_64();
 
 // Declaration
+uint64_t random_64();
+
+// Definition
+inline uint64_t random_64() 
+{
+    return _random_64();
+}
+#endif
+
+extern uint32_t _random_32();
+extern uint16_t _random_16();
+
+extern uint8_t _rdrand_capability();
+extern uint8_t _rdseed_capability();
+
+/*
+ * Declarations
+ */
+uint32_t random_32();
+uint16_t random_16();
 bool is_rdrand_available();
 bool is_rdseed_available();
 
-// Definition
+/*
+ * Definitions
+ */
+inline uint32_t random_32() 
+{
+    return _random_32();
+}
+
+inline uint16_t random_16() 
+{
+    return _random_16();
+}
+
 /**
  * Returns True if RDRAND capability is available.
  * Returns False otherwise.
  */
 inline bool is_rdrand_available()
 {
-    if (rdrand_capability()) {
+    if (_rdrand_capability()) {
         return true;
     }
 
@@ -59,7 +84,7 @@ inline bool is_rdrand_available()
  */
 inline bool is_rdseed_available()
 {
-    if (rdseed_capability()) {
+    if (_rdseed_capability()) {
         return true;
     }
 

--- a/src/random_32.S
+++ b/src/random_32.S
@@ -1,11 +1,10 @@
 /**
- *
  * Simple x86 assembly routines to retrieve 32-bit and
  * 16-bit true random numbers and random number seeds 
  * using Intel's DRNG instructions.
  * 
  * TODO:
- *   - Provide RDSEED instruction support
+ *   - Provide RDSEED instruction based generation of seeds
  * 
  * Reference:
  *  - https://software.intel.com/en-us/articles/intel-digital-random-number-generator-drng-software-implementation-guide
@@ -15,15 +14,15 @@
  *
  */
 
-.global random_32
-.global random_16
-.global rdrand_capability
-.global rdseed_capability
+.global _random_32
+.global _random_16
+.global _rdrand_capability
+.global _rdseed_capability
 
 /*
  * Returns 1 if RDRAND capability is available; 0 otherwise
  */
-rdrand_capability:
+_rdrand_capability:
    push  %ebp
    mov   %esp, %ebp
 
@@ -54,7 +53,7 @@ done_rdrand:
 /*
  * Returns 1 if RDSEED capability is available; 0 otherwise
  */
-rdseed_capability:
+_rdseed_capability:
    push  %ebp
    mov   %esp, %ebp
 
@@ -84,7 +83,7 @@ done_rdseed:
    ret
 
 /* 32-bit random number */
-random_32:
+_random_32:
     push %ebp
     mov  %esp, %ebp
 
@@ -97,7 +96,7 @@ retry32:
     ret
 
 /* 16-bit random number */
-random_16:
+_random_16:
     push %ebp
     mov  %esp, %ebp
 

--- a/src/random_64.S
+++ b/src/random_64.S
@@ -1,11 +1,10 @@
 /**
- *
  * Simple x86_64 assembly routines to retrieve 64-bit, 32-bit
  * and 16-bit true random numbers and random number seeds 
  * using Intel's DRNG instructions.
  *
  * TODO:
- *   - Provide RDSEED instruction support
+ *   - Provide RDSEED instruction based generation of seeds
  *
  * Reference:
  *  - https://software.intel.com/en-us/articles/intel-digital-random-number-generator-drng-software-implementation-guide
@@ -15,16 +14,16 @@
  *
  */
 
-.global random_64
-.global random_32
-.global random_16
-.global rdrand_capability
-.global rdseed_capability
+.global _random_64
+.global _random_32
+.global _random_16
+.global _rdrand_capability
+.global _rdseed_capability
 
 /*
  * Returns 1 if RDRAND capability is available; 0 otherwise
  */
-rdrand_capability:
+_rdrand_capability:
    push  %rbp
    movq  %rsp, %rbp
 
@@ -55,7 +54,7 @@ done_rdrand:
 /*
  * Returns 1 if RDSEED capability is available; 0 otherwise
  */
-rdseed_capability:
+_rdseed_capability:
    push  %rbp
    mov   %rsp, %rbp
 
@@ -86,7 +85,7 @@ done_rdseed:
 
 
 /* 64-bit random number */
-random_64:
+_random_64:
     push  %rbp
     movq  %rsp, %rbp
 
@@ -99,7 +98,7 @@ retry64:
     retq
 
 /* 32-bit random number */
-random_32:
+_random_32:
     push  %rbp
     movq  %rsp, %rbp
 
@@ -112,7 +111,7 @@ retry32:
     retq
 
 /* 16-bit random number */
-random_16:
+_random_16:
     push  %rbp
     movq  %rsp, %rbp
 


### PR DESCRIPTION
OS X follows System-V ABI, unlike Linux, for ASM routines invoked from C code needs to be begin with an underscore.

Tested on Mac OS and Linux (thankfully, backwards compatible with Linux).

Updating the header file to indicate these fixes.

Closes #3 