### PR TITLE
Adding Support for C++

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,35 @@
 CC=gcc
-CFLAGS=-g -I ./include
+CXX=g++
+CFLAGS=-g
+CXXFLAGS=-g
+INCLUDE=-I ./include
 ARCH=
 DEPS=./include/intel_random.h ./src/*.S
-BIN_32=test_random_32
-BIN_64=test_random_64
+C_BIN_32=test_c_random_32
+C_BIN_64=test_c_random_64
+CPP_BIN_32=test_cpp_random_32
+CPP_BIN_64=test_cpp_random_64
+
+BINS=$(C_BIN_32) $(C_BIN_64) $(CPP_BIN_32) $(CPP_BIN_64)
 
 all: x86 x86_64 
 
-x86: $(DEPS)
-	$(CC) -o $(BIN_32) ./src/random_32.S ./test/test_random.c -m32 $(CFLAGS)
+x86: x86_c x86_cpp
 
-x86_64: $(DEPS)
-	$(CC) -o $(BIN_64) ./src/random_64.S ./test/test_random.c -m64 $(CFLAGS)
+x86_64: x86_64_c x86_64_cpp
+
+x86_c: $(DEPS)
+	$(CC) $(CFLAGS) $(INCLUDE) -o $(C_BIN_32) ./src/random_32.S ./test/test_random.c -m32
+
+x86_64_c: $(DEPS)
+	$(CC) $(CFLAGS) $(INCLUDE) -o $(C_BIN_64) ./src/random_64.S ./test/test_random.c -m64
+
+x86_cpp: $(DEPS)
+	$(CXX) $(CXXFLAGS) $(INCLUDE) -o $(CPP_BIN_32) ./src/random_32.S ./test/test_random.cpp -m32
+
+x86_64_cpp: $(DEPS)
+	$(CXX) $(CXXFLAGS) $(INCLUDE) -o $(CPP_BIN_64) ./src/random_64.S ./test/test_random.cpp -m64
+
 
 clean:
-	rm -f *.o $(BIN_64) $(BIN_32) 
+	rm -f *.o $(BINS) 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ user@host:/some/dir/git/intel-drng$ make x86_64
 # To use clang compilers
 user@host:/some/dir/git/intel-drng$ make CC=clang CXX=clang++
 
-# To use gcc C compiler and `clang` C++ compiler
+# To use gcc C compiler and clang C++ compiler
 user@host:/some/dir/git/intel-drng$ make CC=gcc CXX=clang++
 
 # To run the generated 64-bit C binary

--- a/README.md
+++ b/README.md
@@ -1,16 +1,21 @@
 # Intel Digital Random Number Generator (DRNG) Utility
 ### A simple (fun) project that illustrates the use of Intel's DRNG capabilities for random number generation and random seed generation.
 
-Minimal x86/x86_64 assembly code to invoke the RDRAND/RDSEED instructions from C source. **_There is a single header file (that needs to be included) and a couple of ASM (.S) files (which actually implement the routines that invoke the `RDSEED` and `RDRAND` instructions._**
+Minimal x86/x86_64 assembly code to invoke the RDRAND/RDSEED instructions from C/C++ source. **_There is a single header file (that needs to be included) and a couple of ASM (.S) files (which actually implement the routines that invoke the `RDSEED` and `RDRAND` instructions._**
 
 **Tested with the following compiler(s)**:
  * Linux
-     * `gcc version 7.4.0 (Ubuntu 7.4.0-1ubuntu1~18.04.1) - Target: x86_64-linux-gnu`
-     * `clang version 6.0.0-1ubuntu2 (tags/RELEASE_600/final) - Target: x86_64-pc-linux-gnu`
+     * C
+         * `gcc version 7.4.0 (Ubuntu 7.4.0-1ubuntu1~18.04.1) - Target: x86_64-linux-gnu`
+         * `clang version 6.0.0-1ubuntu2 (tags/RELEASE_600/final) - Target: x86_64-pc-linux-gnu`
+     * C++
+         * `(g++) gcc version 7.4.0 (Ubuntu 7.4.0-1ubuntu1~18.04.1) - Target: x86_64-linux-gnu`
+         * `clang version 6.0.0-1ubuntu2 (tags/RELEASE_600/final) - Target: x86_64-pc-linux-gnu`
  * OS X
-     * `Apple clang version 11.0.0 (clang-1100.0.33.17) - Target: x86_64-apple-darwin19.3.0`
+     * C
+         * `Apple clang version 11.0.0 (clang-1100.0.33.17) - Target: x86_64-apple-darwin19.3.0`
 
-We have provided a few simple test programs to show the usage. To build these tests, follow the instructions below. To be able to build both x86 and x86_64, appropriate compiler toolchains need to be installed (outside the scope of this manual):
+We have provided a few simple C and C++ test programs to show the usage. To build these tests, follow the instructions below. To be able to build both x86 and x86_64, appropriate compiler toolchains need to be installed (outside the scope of this manual):
 
 ```bash
 # Make all (x86 and x86_64 targets)
@@ -20,14 +25,23 @@ We have provided a few simple test programs to show the usage. To build these te
 user@host:/some/dir/git/intel-drng$ make x86
 user@host:/some/dir/git/intel-drng$ make x86_64
 
-# To use clang
-user@host:/some/dir/git/intel-drng$ make CC=clang
+# To use `clang` compilers
+user@host:/some/dir/git/intel-drng$ make CC=clang CXX=clang++
 
-# To run the generated 64-bit binary
-user@host:/some/dir/git/intel-drng$ ./test_random_64
+# To use `gcc` C compiler and `clang` C++ compiler
+user@host:/some/dir/git/intel-drng$ make CC=gcc CXX=clang++
 
-# To run the generated 32-bit binary
-user@host:/some/dir/git/intel-drng$ ./test_random_32
+# To run the generated 64-bit C binary
+user@host:/some/dir/git/intel-drng$ ./test_c_random_64
+
+# To run the generated 32-bit C binary
+user@host:/some/dir/git/intel-drng$ ./test_c_random_32
+
+# To run the generated 64-bit C++ binary
+user@host:/some/dir/git/intel-drng$ ./test_cpp_random_64
+
+# To run the generated 32-bit C binary
+user@host:/some/dir/git/intel-drng$ ./test_cpp_random_32
 ```
 
 **References:**

--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@ We have provided a few simple C and C++ test programs to show the usage. To buil
 user@host:/some/dir/git/intel-drng$ make x86
 user@host:/some/dir/git/intel-drng$ make x86_64
 
-# To use `clang` compilers
+# To use clang compilers
 user@host:/some/dir/git/intel-drng$ make CC=clang CXX=clang++
 
-# To use `gcc` C compiler and `clang` C++ compiler
+# To use gcc C compiler and `clang` C++ compiler
 user@host:/some/dir/git/intel-drng$ make CC=gcc CXX=clang++
 
 # To run the generated 64-bit C binary
@@ -40,7 +40,7 @@ user@host:/some/dir/git/intel-drng$ ./test_c_random_32
 # To run the generated 64-bit C++ binary
 user@host:/some/dir/git/intel-drng$ ./test_cpp_random_64
 
-# To run the generated 32-bit C binary
+# To run the generated 32-bit C++ binary
 user@host:/some/dir/git/intel-drng$ ./test_cpp_random_32
 ```
 

--- a/include/intel_random.h
+++ b/include/intel_random.h
@@ -25,6 +25,12 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+// This block is required to allow C++ compatibility.
+// See the corresponding scope closing at the end of the file.
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #ifdef __x86_64__
 extern uint64_t _random_64();
 
@@ -36,7 +42,7 @@ inline uint64_t random_64()
 {
     return _random_64();
 }
-#endif
+#endif // __x86_64__
 
 extern uint32_t _random_32();
 extern uint16_t _random_16();
@@ -90,5 +96,9 @@ inline bool is_rdseed_available()
 
     return false;
 }
+
+#ifdef __cplusplus
+}
+#endif // __cplusplus
 
 #endif // _INTEL_RANDOM_H_

--- a/test/test_random.c
+++ b/test/test_random.c
@@ -5,7 +5,7 @@
 
 void generate_random_numbers()
 {
-    // Generate a random number of [1..65535] random numbers
+    // Generate a random number ([1..65535]) of random numbers
     const uint16_t NUM_OF_RAND = random_16();
     printf ("Generating %d random numbers...\n", NUM_OF_RAND);
 
@@ -24,8 +24,6 @@ void generate_random_numbers()
     }
 
     printf ("Generated %d random numbers...\n", NUM_OF_RAND);
-
-
 }
 
 int main (int argc, char *argv[])

--- a/test/test_random.cpp
+++ b/test/test_random.cpp
@@ -1,0 +1,78 @@
+#include <iostream>
+
+#include "intel_random.h"
+
+class RandomNumber
+{
+    public:
+        static bool IsRdrandAvailable ()
+        {
+            return is_rdrand_available();
+        }
+
+        static bool IsRdseedAvailable ()
+        {
+            return is_rdseed_available();
+        }
+#ifdef __x86_64__
+        static uint64_t GetNextRandom64 ()
+        {
+            return random_64();
+        }
+#endif
+
+        static uint32_t GetNextRandom32 ()
+        {
+            return random_32();
+        }
+
+        static uint16_t GetNextRandom16 ()
+        {
+            return random_16();
+        }
+    
+    private:
+        RandomNumber () { }
+        virtual ~RandomNumber () = 0;
+};
+
+void GenerateRandomNumbers()
+{
+    // Generate a random number ([1..65535]) of random numbers
+    const uint16_t NUM_OF_RAND = random_16();
+    std::cout << "Generating " << NUM_OF_RAND << " random numbers..." << std::endl;
+
+    for (int i = 0; i < NUM_OF_RAND; i++) {
+#ifdef __x86_64__
+        uint64_t r64 = RandomNumber::GetNextRandom64();
+        std::cout << "64-bit Random Number: " << r64 << std::endl;
+#endif
+        uint32_t r32 = RandomNumber::GetNextRandom32(); 
+        uint16_t r16 = RandomNumber::GetNextRandom16(); 
+
+        std::cout << "32-bit Random Number: " << r32 << std::endl;
+        std::cout << "16-bit Random Number: " << r16 << std::endl;
+
+        printf("----------------------------------\n");
+    }
+
+    std::cout << "Generated " << NUM_OF_RAND << " random numbers..." << std::endl;
+}
+
+int main (int argc, char *argv[])
+{
+    if (RandomNumber::IsRdrandAvailable()) {
+        std::cout<< "Intel DRNG RDRAND Support Available" << std::endl;
+        GenerateRandomNumbers();
+    } else {
+        std::cout<< "Intel DRNG RDRAND Support Not Available" << std::endl;
+    }
+
+    if (RandomNumber::IsRdseedAvailable()) {
+        std::cout << "Intel DRNG RDSEED Support Available" << std::endl;
+    } else {
+        std::cout << "Intel DRNG RDSEED Support Not available" << std::endl;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
Using the (oh well)  `extern "C"` magic within the header file to make C++ compiler happy.

Currently, we use the extern "C" method to essentially conditionally nest the entire header file. Thanks to the pre-processor, this works!

Investigate if there is a better way to handle this.

Adding an example C++ test program to demonstrate usage. Updating the Makefile to allow invoking C++ compiler to build the C++ examples.

Closes #5 