### PR TITLE
Improve/enhance the header file to allow being used in Linux kernel modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Minimal x86/x86_64 assembly code to invoke the RDRAND/RDSEED instructions from C
 
 Given that these instructions don't require any Ring 0 privileges, they can be invoked from user space. Also, they are _container friendly_; Any applications running inside a Docker/LXC container can invoke these DRNG instructions.
 
-This library is also usable in Linux kernel modules (LKM). See the instructions [below](#-linux-kernel-module-use).
+This library is also usable in Linux kernel modules (LKM). See the instructions [below](#linux-kernel-module-use).
 
 **Tested with the following compiler(s)**:
  * Linux

--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # Intel Digital Random Number Generator (DRNG) Utility
-### A simple (fun) project that illustrates the use of Intel's DRNG capabilities for random number generation and random seed generation.
+### A simple (fun) project that illustrates the use of Intel's DRNG capabilities for random number and random seed generation.
 
-Minimal x86/x86_64 assembly code to invoke the RDRAND/RDSEED instructions from C/C++ source. **_There is a single header file (that needs to be included) and a couple of ASM (.S) files (which actually implement the routines that invoke the `RDSEED` and `RDRAND` instructions._**. Relies on the `CPUID` instruction to determine whether the processor supports these capabilities.
+Minimal x86/x86_64 assembly code to invoke the RDRAND/RDSEED instructions from C/C++ source. **_There is a single header file (that needs to be included) and a couple of ASM (.S) files (which actually implement the routines that invoke the `RDSEED` and `RDRAND` instructions._**. Relies on the **`CPUID`** instruction to determine whether the processor supports these capabilities.
 
 Given that these instructions don't require any Ring 0 privileges, they can be invoked from user space. Also, they are _container friendly_; Any applications running inside a Docker/LXC container can invoke these DRNG instructions.
+
+This library is also usable in Linux kernel modules (LKM). See the instructions [below](#-linux-kernel-module-use).
 
 **Tested with the following compiler(s)**:
  * Linux
@@ -21,7 +23,7 @@ We have provided a few simple C and C++ test programs to show the usage. To buil
 
 ```bash
 # Make all (x86 and x86_64 targets)
-[user@host:/some/dir/git/intel-drng] make
+user@host:/some/dir/git/intel-drng$ make
 
 # Make only x86/x86_64 targets
 user@host:/some/dir/git/intel-drng$ make x86
@@ -44,6 +46,45 @@ user@host:/some/dir/git/intel-drng$ ./test_cpp_random_64
 
 # To run the generated 32-bit C++ binary
 user@host:/some/dir/git/intel-drng$ ./test_cpp_random_32
+```
+
+### Linux Kernel Module Use
+
+This RDRAND/RDSEED library can also be used within Linux kernel modules (LKM) in case true random numbers or seeds are needed in kernel space code. The same ASM source as well as the header files are usable. The trick is to have the Kbuild setup correctly to have the ASM source and header files be available for building. **_We assume that appropriate kernel headers and build tools are installed_**.
+
+```
+# Go to the `lkm-1` directory
+user@host:/some/dir/git/intel-drng$ cd test/lkm-1
+
+# Build the example LKM. Notice that the `MODULE_HOME` is set to the base of the `intel-drng` project directory
+user@host:/some/dir/git/intel-drng/test/lkm-1$ make MODULE_HOME=/some/dir/git/intel-drng
+
+# The generated LKM is the `intel-drng.ko` file. Load the module.
+user@host:/some/dir/git/intel-drng/test/lkm-1$ sudo insmod ./intel-drng.ko
+
+# See the kernel log output
+user@host:/some/dir/git/intel-drng/test/lkm-1$ dmesg
+...
+...
+[10573524.704585] Loading Intel DRNG Accessor Module
+[10573524.704587] 64-bit Random Number: 2181635107122498510
+[10573524.704587] 32-bit Random Number: 2218904060
+[10573524.704588] 16-bit Random Number: 30025
+
+# Unload the kernel module
+user@host:/some/dir/git/intel-drng/test/lkm-1$ sudo rmmod intel-drng.ko
+
+# See the kernel log after unloading
+user@host:/some/dir/git/intel-drng/test/lkm-1$ dmesg
+...
+...
+[10573670.742170] Unloading Intel DRNG Accessor Module... Goodbye!
+[10573670.742173] 64-bit Random Number: 11810063415406240295
+[10573670.742175] 32-bit Random Number: 3370028278
+[10573670.742177] 16-bit Random Number: 45916
+
+# Cleanup
+user@host:/some/dir/git/intel-drng/test/lkm-1$ make clean
 ```
 
 **References:**

--- a/include/intel_drng.h
+++ b/include/intel_drng.h
@@ -37,14 +37,14 @@ extern "C" {
 #define TRUE 1
 #define FALSE 0
 #else             // Userspace applications
-// Use standard C unsigned integer types
+#include <stdint.h>
+#include <stdbool.h>
 #define U16 uint16_t
+// Use standard C unsigned integer types
 #define U32 uint32_t 
 #define BOOL bool
 #define TRUE true 
 #define FALSE false
-#include <stdint.h>
-#include <stdbool.h>
 #endif
 
 #ifdef __x86_64__  // If the host is 64-bit capable

--- a/include/intel_drng.h
+++ b/include/intel_drng.h
@@ -22,51 +22,75 @@
 #ifndef _INTEL_RANDOM_H_
 #define _INTEL_RANDOM_H_
 
-#include <stdint.h>
-#include <stdbool.h>
-
 // This block is required to allow C++ compatibility.
 // See the corresponding scope closing at the end of the file.
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-#ifdef __x86_64__
-extern uint64_t _random_64();
+#ifdef __KERNEL__ // Needed for kernel modules
+#include <linux/types.h>
+// Use Linux kernel's unsigned integer types
+#define U16 u16
+#define U32 u32
+#define BOOL u8
+#define TRUE 1
+#define FALSE 0
+#else             // Userspace applications
+// Use standard C unsigned integer types
+#define U16 uint16_t
+#define U32 uint32_t 
+#define BOOL bool
+#define TRUE true 
+#define FALSE false
+#include <stdint.h>
+#include <stdbool.h>
+#endif
+
+#ifdef __x86_64__  // If the host is 64-bit capable
+#ifdef __KERNEL__
+// Use Linux kernel's unsigned integer types
+#define U64 u64
+#else
+// Use standard C unsigned integer types
+#define U64 uint64_t
+#endif
+
+extern U64 _random_64(void);
 
 // Declaration
-uint64_t random_64();
+U64 random_64(void);
 
 // Definition
-inline uint64_t random_64() 
+inline U64 random_64(void) 
 {
     return _random_64();
 }
 #endif // __x86_64__
 
-extern uint32_t _random_32();
-extern uint16_t _random_16();
+extern U32 _random_32(void);
+extern U16 _random_16(void);
 
-extern uint8_t _rdrand_capability();
-extern uint8_t _rdseed_capability();
+extern uint8_t _rdrand_capability(void);
+extern uint8_t _rdseed_capability(void);
 
 /*
  * Declarations
  */
-uint32_t random_32();
-uint16_t random_16();
-bool is_rdrand_available();
-bool is_rdseed_available();
+U32 random_32(void);
+U16 random_16(void);
+BOOL is_rdrand_available(void);
+BOOL is_rdseed_available(void);
 
 /*
  * Definitions
  */
-inline uint32_t random_32() 
+inline U32 random_32(void) 
 {
     return _random_32();
 }
 
-inline uint16_t random_16() 
+inline U16 random_16(void) 
 {
     return _random_16();
 }
@@ -75,26 +99,26 @@ inline uint16_t random_16()
  * Returns True if RDRAND capability is available.
  * Returns False otherwise.
  */
-inline bool is_rdrand_available()
+inline BOOL is_rdrand_available(void)
 {
     if (_rdrand_capability()) {
-        return true;
+        return TRUE;
     }
 
-    return false;
+    return FALSE;
 }
 
 /**
  * Returns True if RDSEED capability is available.
  * Returns False otherwise.
  */
-inline bool is_rdseed_available()
+inline BOOL is_rdseed_available(void)
 {
     if (_rdseed_capability()) {
-        return true;
+        return TRUE;
     }
 
-    return false;
+    return FALSE;
 }
 
 #ifdef __cplusplus

--- a/test/lkm-1/Kbuild
+++ b/test/lkm-1/Kbuild
@@ -1,0 +1,8 @@
+EXTRA_CFLAGS = -Wall -g
+MODULE_HOME = ""
+
+obj-m += intel-drng.o
+
+ccflags-y = -I$(MODULE_HOME)/include -Wall -g
+intel-drng-y = intel_drng.o
+intel-drng-y += ../../src/random_64.o

--- a/test/lkm-1/Makefile
+++ b/test/lkm-1/Makefile
@@ -1,0 +1,8 @@
+KDIR = /lib/modules/`uname -r`/build
+
+kbuild:
+	make -C $(KDIR) M=`pwd`
+
+clean:
+	make -C $(KDIR) M=`pwd` clean
+	rm -f ../../src/*.o ../../src/.*.cmd

--- a/test/lkm-1/intel_drng.c
+++ b/test/lkm-1/intel_drng.c
@@ -1,0 +1,35 @@
+#include <linux/module.h>	/* Needed by all modules */
+#include <linux/kernel.h>	/* Needed for KERN_INFO */
+#include <linux/types.h>
+
+#include "intel_drng.h"
+
+static int drng_init(void)
+{
+	printk(KERN_INFO "Loading Intel DRNG Accessor Module\n");
+#ifdef __x86_64__
+    printk(KERN_INFO "64-bit Random Number: %llu\n", random_64());
+#endif
+    printk(KERN_INFO "32-bit Random Number: %u\n", random_32());
+    printk(KERN_INFO "16-bit Random Number: %u\n", random_16());
+
+    return 0;
+}
+
+static void drng_exit(void)
+{
+	printk(KERN_INFO "Unloading Intel DRNG Accessor Module... Goodbye!\n");
+#ifdef __x86_64__
+    printk(KERN_INFO "64-bit Random Number: %llu\n", random_64());
+#endif
+    printk(KERN_INFO "32-bit Random Number: %u\n", random_32());
+    printk(KERN_INFO "16-bit Random Number: %u\n", random_16());
+}
+
+module_init(drng_init);
+module_exit(drng_exit);
+
+MODULE_AUTHOR("Abhinava Sadasivarao");
+MODULE_DESCRIPTION("A simple kernel module that generates random numbers using Intel DRNG.");
+MODULE_LICENSE("MIT");
+MODULE_VERSION("1.0");


### PR DESCRIPTION
Adding additional `#ifdef` blocks to allow usage in the context of Linux kernel modules. Adding a very simple LKM to illustrate usage.

Closes #8 